### PR TITLE
Keep Share Buttons Only for Mobile Version

### DIFF
--- a/src/app/(portal)/blog/comedians-rating/page.tsx
+++ b/src/app/(portal)/blog/comedians-rating/page.tsx
@@ -129,12 +129,10 @@ export default function ComediansRatingPage() {
                 <div className="flex items-center gap-x-2 text-sm text-gray-500">
                     <CalendarIcon size={16} /> 12 декабря 2025
                 </div>
-                <div className="block sm:hidden">
-                    <Share
-                        title="Тирлист комиков по версии подписчиков Давида Квахаджелидзе"
-                        url={`${process.env.NEXT_PUBLIC_WEBSITE_DOMAIN}/blog/comedians-rating`}
-                    />
-                </div>
+                <Share
+                    title="Тирлист комиков по версии подписчиков Давида Квахаджелидзе"
+                    url={`${process.env.NEXT_PUBLIC_WEBSITE_DOMAIN}/blog/comedians-rating`}
+                />
                 <p>
                     Стендап-комик{' '}
                     <Link

--- a/src/app/(portal)/blog/subscriptions/page.tsx
+++ b/src/app/(portal)/blog/subscriptions/page.tsx
@@ -54,12 +54,10 @@ export default function SubscriptionsPage() {
                 <div className="flex items-center gap-x-2 text-sm text-gray-500">
                     <CalendarIcon size={16} /> 04 декабря 2025
                 </div>
-                <div className="block sm:hidden">
-                    <Share
-                        title="Подписка на комиков и группы — чтобы ничего не пропускать"
-                        url={`${process.env.NEXT_PUBLIC_WEBSITE_DOMAIN}/blog/subscriptions`}
-                    />
-                </div>
+                <Share
+                    title="Подписка на комиков и группы — чтобы ничего не пропускать"
+                    url={`${process.env.NEXT_PUBLIC_WEBSITE_DOMAIN}/blog/subscriptions`}
+                />
                 <p>
                     Мы добавили новую полезную функцию - <strong>подписки на комиков и группы</strong>.
                 </p>

--- a/src/app/(portal)/blog/top-3-specials-2025/page.tsx
+++ b/src/app/(portal)/blog/top-3-specials-2025/page.tsx
@@ -57,12 +57,10 @@ export default function Top3Specials2025Page() {
                 <div className="flex items-center gap-x-2 text-sm text-gray-500">
                     <CalendarIcon size={16} /> 01 января 2026
                 </div>
-                <div className="block sm:hidden">
-                    <Share
-                        title="Топ спешлов 2025 года: итоги года в русскоязычной комедии"
-                        url={`${process.env.NEXT_PUBLIC_WEBSITE_DOMAIN}/blog/top-3-specials-2025`}
-                    />
-                </div>
+                <Share
+                    title="Топ спешлов 2025 года: итоги года в русскоязычной комедии"
+                    url={`${process.env.NEXT_PUBLIC_WEBSITE_DOMAIN}/blog/top-3-specials-2025`}
+                />
                 <p>
                     Год подошёл к&nbsp;концу&nbsp;&mdash; и&nbsp;можно уверенно сказать: 2025-й получился по-настоящему
                     интересным и насыщенным для русскоязычной комедии. Новые имена, громкие возвращения, эксперименты

--- a/src/components/ui/share.tsx
+++ b/src/components/ui/share.tsx
@@ -44,7 +44,7 @@ export const Share = ({ title, text, url }: ShareProps) => {
         <Button
             size="lg"
             variant="outline"
-            className="flex w-full items-center justify-center gap-x-2"
+            className="flex w-full items-center justify-center gap-x-2 sm:hidden"
             onClick={handleShare}
         >
             <ShareIcon size={24} strokeWidth={2.5} />


### PR DESCRIPTION
https://github.com/comedy-portal/frontend/issues/133

Display share buttons exclusively on the mobile version of the site and hide them on desktop layout.